### PR TITLE
Component definition tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 working_dir/*
 templates/.trestle/cache/
+templates/.trestle/_trash/

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This repository contains the source code for the `ghcr.io/gsa-tts/trestle` Docke
 
 ### General workflow:
 
+1. [Download trestle image and run CLI](#pull-down-the-trestle-image-and-initialize-a-compliance-trestle-project)
 1. [Create the files for a given SSPP](#create-control-statement-markdown-files)
-1. Edit control statements within markdown files
-1. [Assemble markdown contents into a provisional OSCAL SSP](#assemble-ssp-json-from-markdown)
-1. Edit other sections of the SSPP within the smaller json files
+1. Do in a loop:
+    1. Edit control statements within markdown files
+    1. [Assemble markdown contents into a provisional OSCAL SSP](#assemble-ssp-json-from-markdown)
+    1. Edit other sections of the SSPP within the smaller json files
 1. [Assemble everything into a final OSCAL SSP (TODO: within a CI workflow)](#final-ssp-assembly)
 
 ### Pull down the trestle image and initialize a compliance trestle project
@@ -25,15 +27,20 @@ All other usage commands assume you are operating within the docker container.
 
 ### Create Control Statement Markdown Files
 
-`generate-ssp-markdown PROFILE_NAME`
-
 If you are using a profile that isn't [shipped with the image](#templates) you must [import it first](#import-profile-into-working-space)
+
+If you are utilizing Component Definitions, you must [import](#import-component-definition-into-working-space) and/or [create](#create-component-definition) them first.
+
+`generate-ssp-markdown -p PROFILE_NAME [-c COMP_DEF_NAMES]`
+
 
 ### Assemble SSP JSON from Markdown
 
-`assemble-ssp-json SYSTEM_NAME`
+`assemble-ssp-json -n SYSTEM_NAME [-c COMP_DEF_NAMES]`
 
 This step will create `system-security-plans/SYSTEM_NAME/system-security-plan.json` as well as smaller JSON files within `system-security-plans/SYSTEM_NAME/system-security-plan/` for editing.
+
+This script should be given the same list of Component Definitions that were passed to `generate-ssp-markdown`
 
 ### Final SSP Assembly
 
@@ -46,6 +53,18 @@ If you are using a `PROFILE_NAME` that does not ship with this docker container 
 `trestle import -f PROFILE_URL -o PROFILE_NAME`
 
 Once that is done you can go back to the `generate-ssp-markdown` step
+
+### Import Component Definition into working space:
+
+To import a component that [ships with](#templates) this docker container: `copy-component -n COMPONENT_NAME`
+
+To import a component that is available from a URL: `copy-component -n COMPONENT_NAME -u COMPONENT_URL`
+
+### Create Component Definition
+
+`create-component -n COMPONENT_NAME`
+
+And then edit the created files to contain the component definition.
 
 ### Split SSP into manageable files
 
@@ -60,6 +79,10 @@ The following templates are included in the Docker image:
 #### profiles/lato
 
 A profile representing the set of controls covered by a [GSA LATO](https://www.gsa.gov/system/files/Lightweight-Security-Authorization-Process-%28LATO%29%20%5BCIO-IT-Security-14-68-Rev-7%5D%2009-17-2021docx%20%281%29.pdf) SSPP.
+
+#### component-definitions/cloud_gov
+
+A Component Definition representing the Cloud.gov CRM.
 
 #### catalogs/nist800-53r5
 

--- a/scripts/assemble-ssp-json
+++ b/scripts/assemble-ssp-json
@@ -1,23 +1,63 @@
 #! /usr/bin/env bash
 
+usage="
+$0: Assemble markdown controls into an OSCAL JSON SSP
+
+Usage:
+    $0 -h
+    $0 -n SYSTEM_NAME [-c COMMA_SEP_COMPDEFS] [-m MARKDOWN_DIR] [-r]
+
+Options:
+-h: show help and exit
+-n: System Name
+-c: Comma-separated list of ComponentDefinitions to include. Optional
+-m: Directory containing markdown files. Defaults to control-statements
+-r: Regenerate UUIDs
+"
+
 set -e
 
-if [ "$1" = "" ]; then
-    echo "Usage: $0 SYSTEM_NAME"
+declare -a optional_args
+markdown="control-statements"
+system_name=""
+
+while getopts "hn:c:m:r" opt; do
+    case "$opt" in
+        n)
+            system_name=${OPTARG}
+            ;;
+        c)
+            optional_args+=("-cd" ${OPTARG})
+            ;;
+        m)
+            markdown=${OPTARG}
+            ;;
+        r)
+            optional_args+=("-r")
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$system_name" = "" ]; then
+    echo "$usage"
     exit 1
 fi
 
-if [ -d "system-security-plans/$1" ]; then
+if [ -d "system-security-plans/$system_name" ]; then
     cwd=`pwd`
-    cd "system-security-plans/$1"
+    cd "system-security-plans/$system_name"
     merge-ssp
     cd $cwd
 else
     echo "No existing SSP found, skipping the merge step"
 fi
 
-trestle author ssp-assemble -o "$1" -m control-statements
+trestle author ssp-assemble -o "$system_name" -m "$markdown" "${optional_args[@]}"
 
-if [ -d "system-security-plans/$1" ]; then
-    split-ssp "system-security-plans/$1/system-security-plan.json"
+if [ -d "system-security-plans/$system_name" ]; then
+    split-ssp "system-security-plans/$system_name/system-security-plan.json"
 fi

--- a/scripts/copy-component
+++ b/scripts/copy-component
@@ -1,0 +1,45 @@
+#! /usr/bin/env bash
+
+usage="
+$0: Copy Component Definition from within the templates directory or from the network
+
+Usage:
+    $0 -h
+    $0 -n COMPONENT_NAME [-u COMPONENT_URL]
+
+Options:
+-h: show help and exit
+-n: Local Component Name
+-u: Remote Component URL. Required if COMPONENT_NAME is not shipped in templates folder
+"
+
+set -e
+
+component_name=""
+component_url=""
+
+while getopts "hn:u:" opt; do
+    case "$opt" in
+        n)
+            component_name=${OPTARG}
+            ;;
+        u)
+            component_url=${OPTARG}
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$component_name" = "" ]; then
+    echo "$usage"
+    exit 1
+fi
+
+if [ "$component_url" = "" ]; then
+    component_url="/app/templates/component-definitions/$component_name/component-definition.json"
+fi
+
+trestle import -f "$component_url" -o "$component_name"

--- a/scripts/create-component
+++ b/scripts/create-component
@@ -1,0 +1,45 @@
+#! /usr/bin/env bash
+
+usage="
+$0: Create new minimal Component Definition
+
+Usage:
+    $0 -h
+    $0 -n COMPONENT_NAME
+
+Options:
+-h: show help and exit
+-n: Component Name
+"
+
+set -e
+
+component_name=""
+
+while getopts "hn:" opt; do
+    case "$opt" in
+        n)
+            component_name=${OPTARG}
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$component_name" = "" ]; then
+    echo "$usage"
+    exit 1
+fi
+
+trestle create -t component-definition -o "$component_name"
+trestle create -f "component-definitions/$component_name/component-definition.json" -e "component-definition.components"
+trestle create -f "component-definitions/$component_name/component-definition.json" -e "component-definition.components.0.control-implementations"
+
+echo
+echo "Next steps: update the component-definitions/$component_name/component-definition.json file."
+echo
+echo "You MUST update the components.title field to match the component name you'll use in your SSP markdown"
+echo "You MAY delete all of the contents of the control-implementations field, but that key MUST remain with an array value (may be empty)"
+echo

--- a/scripts/generate-ssp-markdown
+++ b/scripts/generate-ssp-markdown
@@ -1,14 +1,58 @@
 #! /usr/bin/env bash
 
+usage="
+$0: Generate control statement markdown for an SSP
+
+Usage:
+    $0 -h
+    $0 -p PROFILE_NAME [-c COMMA_SEP_COMPDEFS] [-s LEVERAGED_SSP] [-m MARKDOWN_DIR] [-f]
+
+Options:
+-h: show help and exit
+-p: Profile name to base the SSP on
+-c: Comma-separated list of ComponentDefinitions to include. Optional
+-s: SSP to leverage as local name or URL. Optional
+-m: Directory to put markdown files in. Defaults to control-statements
+-f: Force overwrite
+"
+
 set -e
 
-if [ "$1" = "" ]; then
-    echo "Usage: $0 PROFILE_NAME"
+declare -a optional_args
+markdown="control-statements"
+profile=""
+
+while getopts "hp:c:s:m:f" opt; do
+    case "$opt" in
+        p)
+            profile=${OPTARG}
+            ;;
+        c)
+            optional_args+=("-cd" ${OPTARG})
+            ;;
+        s)
+            optional_args+=("-ls" ${OPTARG})
+            ;;
+        m)
+            markdown=${OPTARG}
+            ;;
+        f)
+            optional_args+=("-fo")
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$profile" = "" ]; then
+    echo "$usage"
     exit 1
 fi
 
-if [ ! -d "profiles/$1" ]; then
-    copy-profile $1
+if [ ! -d "profiles/$profile" ]; then
+    copy-profile "$profile"
 fi
 
-trestle author ssp-generate -p "$1" -o control-statements
+trestle author ssp-generate -p "$profile" -o "$markdown" "${optional_args[@]}"

--- a/templates/component-definitions/cloud_gov/component-definition.json
+++ b/templates/component-definitions/cloud_gov/component-definition.json
@@ -2,9 +2,9 @@
   "component-definition": {
     "uuid": "c0b0091e-dee0-4213-b1bd-d1480fcb3b00",
     "metadata": {
-      "title": "Cloud.gov LATO component definition.",
-      "last-modified": "2024-05-29T22:33:54.968281+00:00",
-      "version": "0.0.1",
+      "title": "Cloud.gov LATO CRM",
+      "last-modified": "2024-06-04T13:09:35.288026+00:00",
+      "version": "0.0.2",
       "oscal-version": "1.0.4",
       "roles": [
         {
@@ -32,6 +32,138 @@
         "type": "service",
         "title": "Cloud.gov",
         "description": "The Cloud.gov Platform-as-a-Service",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "value": "fully-inherited",
+            "remarks": "rule_0"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Customer fully inherits this control with no responsibility",
+            "remarks": "rule_0"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-account-management-needed",
+            "remarks": "rule_app_ac"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application accounts are the responsiblity of the application owner",
+            "remarks": "rule_app_ac"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "system-roles-needed",
+            "remarks": "rule_user_roles"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "The system must manage user roles",
+            "remarks": "rule_user_roles"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-supplementary-logging",
+            "remarks": "rule_audit_logging_supplement"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "System must provide additional logging if required",
+            "remarks": "rule_audit_logging_supplement"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-monitoring-scanning-required",
+            "remarks": "rule_app_monitoring"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application scanning and monitoring are the system responsibility",
+            "remarks": "rule_app_monitoring"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-config-control",
+            "remarks": "rule_app_config_control"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application configuration control is the system responsibility",
+            "remarks": "rule_app_config_control"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-redundant-containers",
+            "remarks": "rule_app_redundant_containers"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application owners must ensure multiple instances of application are running",
+            "remarks": "rule_app_redundant_containers"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-mfa-required",
+            "remarks": "rule_application_mfa"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application owners must implement an MFA solution for all accounts",
+            "remarks": "rule_application_mfa"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "egress-control-in-place",
+            "remarks": "rule_app_egress_control"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Customer must ensure egress control is in place",
+            "remarks": "rule_app_egress_control"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-field-level-encryption",
+            "remarks": "rule_app_field_level_encryption"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Customer must further encrypt sensitive data at the field level",
+            "remarks": "rule_app_field_level_encryption"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-event-analysis",
+            "remarks": "rule_app_event_analysis"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application owners are responsible for using automated tools to analyze cloud.gov-supplied events feed",
+            "remarks": "rule_app_event_analysis"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-alert-sla",
+            "remarks": "rule_app_alert_sla"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application owners must establish an SLA with cloud.gov for reporting malicious code detection",
+            "remarks": "rule_app_alert_sla"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "app-log-monitoring",
+            "remarks": "rule_app_log_monitoring"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Application owners are responsible for monitoring their application logs",
+            "remarks": "rule_app_log_monitoring"
+          }
+        ],
         "links": [
           {
             "href": "https://cloud.gov",
@@ -52,47 +184,550 @@
             ]
           }
         ],
-        "props": [
-          {
-            "name": "Rule_Id",
-            "value": "egress_control_in_place",
-            "remarks": "rule_1"
-          },
-          {
-            "name": "Rule_Description",
-            "value": "Customer must ensure egress control is in place",
-            "remarks": "rule_1"
-          },
-          {
-            "name": "Rule_Id",
-            "value": "field_level_encryption_at_rest",
-            "remarks": "rule_2"
-          },
-          {
-            "name": "Rule_Description",
-            "value": "Customer must further encrypt sensitive data at the field level",
-            "remarks": "rule_2"
-          }
-        ],
         "control-implementations": [
           {
             "uuid": "812617fa-8f40-4708-aa93-2c21df5b9699",
             "source": "trestle://profiles/lato/profile.json",
-            "description": "SC family controls implemented by cloud.gov on behalf of resident applications",
+            "description": "Inheritable controls implemented by cloud.gov on behalf of resident applications",
             "implemented-requirements": [
+              {
+                "uuid": "185ebdf8-beec-466f-884c-0d1cfe278ee5",
+                "control-id": "ac-2",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "ac-2_smt.a",
+                    "uuid": "ef27db3f-e055-4d66-a5b6-fd6783af8a3d",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.\n\nThat is, your developer login to cloud.gov where you create/edit/delete applications on the platform would count as covered, but accounts within the applications you create would not be, unless they too integrate with the UAA.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.b",
+                    "uuid": "7062d856-ddc7-4fa5-a9ee-e78dedf1b3af",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.c",
+                    "uuid": "7047cb33-712b-4064-8ab6-117daac17ba8",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.d",
+                    "uuid": "969f6bd2-b214-478f-ba12-894146fbf0b4",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.e",
+                    "uuid": "3cf79634-33f4-4ce7-89f2-438973e03a82",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.f",
+                    "uuid": "d02a3f6a-8db3-4d9e-9c05-c93bb335ae5f",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.g",
+                    "uuid": "18c7d203-a1e7-4157-a411-1f21038a2daa",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.h",
+                    "uuid": "2d610cc9-9225-468e-a634-aee47a1ba9a6",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.i",
+                    "uuid": "16b0de6c-1c52-49cf-b5d6-4c15c074eea4",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.j",
+                    "uuid": "555e091a-c6aa-4e56-9786-4de7369cac38",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ac-2_smt.k",
+                    "uuid": "c739214d-ef3a-4c92-9fc9-0cb0258c25e9",
+                    "description": "For UAA accounts (Cloud Foundry User Account and Authentication accounts, which includes cloud.gov users who log in via agency single sign-on or the cloud.gov identity provider) used to manage applications, cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-account-management-needed"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "3dbcb5aa-d541-4959-920d-34aca80c540b",
+                "control-id": "ac-3",
+                "description": "For UAA accounts used to manage the applications cloud.gov provides this control. Application accounts unless integrated with the UAA are the responsibility of the application owner. The delineation of higher privileged accounts in the application and their monitoring is the responsibility of the application owner.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-account-management-needed"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "413a1883-c009-47ab-9a7a-bcc7e07e103d",
+                "control-id": "ac-6.5",
+                "description": "The roles are defined by cloud.gov but the application owner must make the proper assignments to personnel to ensure least privilege is enforced.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "system-roles-needed"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "13fb863b-864b-4119-920b-32711f97a4db",
+                "control-id": "ac-6.9",
+                "description": "cloud.gov automatically logs privileged actions taken within cloud.gov.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "fully-inherited"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "implemented"
+                  }
+                ]
+              },
+              {
+                "uuid": "bafad407-b0e9-4986-b2ef-fc6a9518e481",
+                "control-id": "au-2",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "au-2_smt.a",
+                    "uuid": "57a24a01-c076-46d8-9ba2-2791dffbe474",
+                    "description": "Application owners must ensure that the auditing provided by cloud.gov meets their requirements and must provide for additional auditing if needed.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-supplementary-logging"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "au-2_smt.b",
+                    "uuid": "18ca26bb-adeb-4e8c-bfd8-52342de9fc4f",
+                    "description": "Application owners must ensure that the auditing provided by cloud.gov meets their requirements and must provide for additional auditing if needed.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-supplementary-logging"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "au-2_smt.c",
+                    "uuid": "fcaf3238-ed1b-4c95-938d-918d8b3d4536",
+                    "description": "Application owners must ensure that the auditing provided by cloud.gov meets their requirements and must provide for additional auditing if needed.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-supplementary-logging"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "au-2_smt.d",
+                    "uuid": "72ae1b20-c7de-4ddb-b5c5-39f162e136a5",
+                    "description": "Application owners must ensure that the auditing provided by cloud.gov meets their requirements and must provide for additional auditing if needed.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-supplementary-logging"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "au-2_smt.e",
+                    "uuid": "163ff6e4-f094-47c7-bda0-e1899516d1bb",
+                    "description": "Application owners must ensure that the auditing provided by cloud.gov meets their requirements and must provide for additional auditing if needed.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-supplementary-logging"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "4fa553d9-c302-4828-88bd-8a1449fd5d11",
+                "control-id": "ca-7",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "ca-7_smt.a",
+                    "uuid": "d918e4c9-7b90-4b50-9e3d-51920c1ad4fb",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.b",
+                    "uuid": "6e18c423-13e8-4cc8-8f89-a78fc7c32521",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.c",
+                    "uuid": "321c78de-a7ee-4ee1-904c-e20b270ee4b5",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.d",
+                    "uuid": "39349c10-9f25-4960-8edd-37fd186b5d5d",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.e",
+                    "uuid": "ea725a89-6ff4-4d91-aaef-142577e6fe70",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.f",
+                    "uuid": "c3583bb7-094f-402c-92f5-51d5233ef503",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "ca-7_smt.g",
+                    "uuid": "8956b1e8-00c0-49d0-8acb-7b854c6810bb",
+                    "description": "Operating systems and DB scans are out of the boundary of application owners. The requirement is bound to the application code and is the responsibility of the application owner.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-monitoring-scanning-required"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "d1f11792-ac1f-4221-9074-592278ceecaf",
+                "control-id": "cm-2.2",
+                "description": "Application owners are responsible for utilizing an automated mechanism to manage the baseline configuration of their applications. All operating systems, network and DB configurations are outside of the application owner boundary.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-config-control"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "76582388-67db-43f5-b64d-cc6b687b4252",
+                "control-id": "cm-6.1",
+                "description": "Application owners are responsible for implementing automated controls to verify their intended state. They can use the cloud.gov API, Terraform, etc. to accomplish this.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-config-control"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "27a14aa7-2959-41d9-8d4d-1d3e0f059db3",
+                "control-id": "cp-7.1",
+                "description": "cloud.gov distributes customer workloads across availability zones. Application owners are responsible for ensuring multiple instances of their application are running in order to take advantage of multiple availability zones.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-redundant-containers"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "8e48ee7f-0e44-45f6-ac2e-22eb0034ba65",
+                "control-id": "ia-2",
+                "description": "Application owners are responsible for implementing a MFA solution for access to their systems and resources. cloud.gov supports customers in leveraging cloud.gov's MFA-enabled authentication system to authenticate government users.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-mfa-required"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "98c750bf-1d3b-4e33-b879-789c84bf205b",
+                "control-id": "ia-2.1",
+                "description": "Application owners are responsible for implementing a MFA solution for access to their systems and resources. cloud.gov supports customers in leveraging cloud.gov's MFA-enabled authentication system to authenticate government users.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-mfa-required"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "cbab3fdd-7df8-4a44-9326-fbc7862651cc",
+                "control-id": "ia-2.2",
+                "description": "Application owners are responsible for implementing a MFA solution for access to their systems and resources. cloud.gov supports customers in leveraging cloud.gov's MFA-enabled authentication system to authenticate government users.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-mfa-required"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
               {
                 "uuid": "11bc932e-561d-4d85-9e6a-86e230c0e725",
                 "control-id": "sc-7",
-                "description": "",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
                 "statements": [
                   {
-                    "uuid": "fb721526-81e6-4cfd-8bb0-363018512a50",
                     "statement-id": "sc-7_smt.a",
+                    "uuid": "fb721526-81e6-4cfd-8bb0-363018512a50",
                     "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
                     "props": [
                       {
                         "name": "Rule_Id",
-                        "value": "egress_control_in_place"
+                        "value": "egress-control-in-place"
                       },
                       {
                         "name": "implementation-status",
@@ -106,13 +741,13 @@
                     ]
                   },
                   {
-                    "uuid": "e9aadfed-281f-454f-a2bb-bf89c42bd5e6",
                     "statement-id": "sc-7_smt.b",
+                    "uuid": "e9aadfed-281f-454f-a2bb-bf89c42bd5e6",
                     "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
                     "props": [
                       {
                         "name": "Rule_Id",
-                        "value": "egress_control_in_place"
+                        "value": "egress-control-in-place"
                       },
                       {
                         "name": "implementation-status",
@@ -126,13 +761,13 @@
                     ]
                   },
                   {
-                    "uuid": "78367d72-7be3-4830-bb12-de9cfa6ffcf4",
                     "statement-id": "sc-7_smt.c",
+                    "uuid": "78367d72-7be3-4830-bb12-de9cfa6ffcf4",
                     "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
                     "props": [
                       {
                         "name": "Rule_Id",
-                        "value": "egress_control_in_place"
+                        "value": "egress-control-in-place"
                       },
                       {
                         "name": "implementation-status",
@@ -153,6 +788,10 @@
                 "description": "Customer applications fully inherit this control from cloud.gov.",
                 "props": [
                   {
+                    "name": "Rule_Id",
+                    "value": "fully-inherited"
+                  },
+                  {
                     "name": "implementation-status",
                     "value": "implemented"
                   }
@@ -165,7 +804,7 @@
                 "props": [
                   {
                     "name": "Rule_Id",
-                    "value": "field_level_encryption_at_rest"
+                    "value": "app-field-level-encryption"
                   },
                   {
                     "name": "implementation-status",
@@ -181,6 +820,169 @@
                   },
                   {
                     "role-id": "customer"
+                  }
+                ]
+              },
+              {
+                "uuid": "2329e13c-f955-41ed-9cc6-ad74a3eda0bc",
+                "control-id": "si-4",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "si-4_smt.a",
+                    "uuid": "fce32587-bf6f-4cbc-b8c0-04590f32102e",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.b",
+                    "uuid": "b20c5f1a-8dd1-41be-ac16-a608accaddee",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.c",
+                    "uuid": "1d328508-7b35-43df-a0fe-21cbe0bb2130",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.d",
+                    "uuid": "05aafbfe-c435-4eeb-81d2-9df8ba830211",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.e",
+                    "uuid": "d158b4f0-fe99-4ea2-a327-2eb5bb63877f",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.f",
+                    "uuid": "d21935b0-aea6-4b76-b86d-e50fa3ea3ba7",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.g",
+                    "uuid": "55edb0f8-e683-4791-99e3-625f80177e65",
+                    "description": "Application owners are responsible for monitoring their application logs for signs of unauthorized activity according to laws and regulations, and applying heightened scrutiny when there is an indication of increased risk.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "app-log-monitoring"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "c3eb1545-3b1f-4200-bef4-3190fcf8f3f4",
+                "control-id": "si-4.2",
+                "description": "cloud.gov supplies a real-time feed of events related to customer applications. Application owners are responsible for using automated tools to interpret and analyze these events.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-event-analysis"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ]
+              },
+              {
+                "uuid": "11947fdd-233b-4f9e-8fa9-302581a9bd94",
+                "control-id": "si-4.4",
+                "description": "Customer applications fully inherit this control from cloud.gov.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "fully-inherited"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "implemented"
+                  }
+                ]
+              },
+              {
+                "uuid": "87687f7d-7eaa-4fcd-9f60-bfc5eea13689",
+                "control-id": "si-4.5",
+                "description": "Application owners must establish the SLA with cloud.gov for reporting malicious code detection that effects the application. cloud.gov will detect files matching AV/Malware signatures in customer application deployments, or uploads, but alerts can only be routed to customers during business hours.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "app-alert-sla"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
                   }
                 ]
               }

--- a/templates/component-definitions/cloud_gov/component-definition.json
+++ b/templates/component-definitions/cloud_gov/component-definition.json
@@ -1,0 +1,193 @@
+{
+  "component-definition": {
+    "uuid": "c0b0091e-dee0-4213-b1bd-d1480fcb3b00",
+    "metadata": {
+      "title": "Cloud.gov LATO component definition.",
+      "last-modified": "2024-05-29T22:33:54.968281+00:00",
+      "version": "0.0.1",
+      "oscal-version": "1.0.4",
+      "roles": [
+        {
+          "id": "provider",
+          "title": "Provider"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "ed1c8027-6b7c-439e-8aa8-355cf46d3244",
+          "type": "organization",
+          "name": "Cloud.gov",
+          "links": [
+            {
+              "href": "https://cloud.gov",
+              "rel": "website"
+            }
+          ]
+        }
+      ]
+    },
+    "components": [
+      {
+        "uuid": "feef8607-5d90-493e-b367-b27b79dcabf6",
+        "type": "service",
+        "title": "Cloud.gov",
+        "description": "The Cloud.gov Platform-as-a-Service",
+        "links": [
+          {
+            "href": "https://cloud.gov",
+            "rel": "reference"
+          }
+        ],
+        "protocols": [
+          {
+            "uuid": "0130b4ef-4561-4363-bab5-1e20b9888e49",
+            "name": "https",
+            "title": "Transport Layer Security",
+            "port-ranges": [
+              {
+                "start": 443,
+                "end": 443,
+                "transport": "TCP"
+              }
+            ]
+          }
+        ],
+        "props": [
+          {
+            "name": "Rule_Id",
+            "value": "egress_control_in_place",
+            "remarks": "rule_1"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Customer must ensure egress control is in place",
+            "remarks": "rule_1"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "field_level_encryption_at_rest",
+            "remarks": "rule_2"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Customer must further encrypt sensitive data at the field level",
+            "remarks": "rule_2"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "812617fa-8f40-4708-aa93-2c21df5b9699",
+            "source": "trestle://profiles/lato/profile.json",
+            "description": "SC family controls implemented by cloud.gov on behalf of resident applications",
+            "implemented-requirements": [
+              {
+                "uuid": "11bc932e-561d-4d85-9e6a-86e230c0e725",
+                "control-id": "sc-7",
+                "description": "",
+                "statements": [
+                  {
+                    "uuid": "fb721526-81e6-4cfd-8bb0-363018512a50",
+                    "statement-id": "sc-7_smt.a",
+                    "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "egress_control_in_place"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ],
+                    "responsible-roles": [
+                      {
+                        "role-id": "customer"
+                      }
+                    ]
+                  },
+                  {
+                    "uuid": "e9aadfed-281f-454f-a2bb-bf89c42bd5e6",
+                    "statement-id": "sc-7_smt.b",
+                    "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "egress_control_in_place"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ],
+                    "responsible-roles": [
+                      {
+                        "role-id": "customer"
+                      }
+                    ]
+                  },
+                  {
+                    "uuid": "78367d72-7be3-4830-bb12-de9cfa6ffcf4",
+                    "statement-id": "sc-7_smt.c",
+                    "description": "Application owners are responsible for ensuring their application does not exchange traffic with systems outside its own boundary over unsanctioned or unmonitored interfaces.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "egress_control_in_place"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "partial"
+                      }
+                    ],
+                    "responsible-roles": [
+                      {
+                        "role-id": "customer"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "0364b4ce-1d30-4d4c-8268-e020b7b01607",
+                "control-id": "sc-8.1",
+                "description": "Customer applications fully inherit this control from cloud.gov.",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "implemented"
+                  }
+                ]
+              },
+              {
+                "uuid": "032738f6-3cf2-4d44-b8d9-bf508343b1d8",
+                "control-id": "sc-28.1",
+                "description": "cloud.gov has built-in cryptographic mechanisms to prevent unauthorized disclosure and modification of data. Customers are responsible for further securing/encrypting any sensitive information in their customer applications, and for auditing the permissions their users have for managing their applications.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "field_level_encryption_at_rest"
+                  },
+                  {
+                    "name": "implementation-status",
+                    "value": "partial"
+                  }
+                ],
+                "responsible-roles": [
+                  {
+                    "role-id": "provider",
+                    "party-uuids": [
+                      "ed1c8027-6b7c-439e-8aa8-355cf46d3244"
+                    ]
+                  },
+                  {
+                    "role-id": "customer"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Changes in this PR:
-------------------

* Created Cloud.gov CRM component definition (only speaks to LATO controls for now)
* Update generate/assemble scripts to work with component definitions
* Add ability to pass a leveraged SSP to the generate script, but that is useless unless you have the full OSCAL SSP to inherit from
* Update README with instructions for using CDs


Closes #8 