### PR TITLE
Add yaml config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ RUN adduser \
 # RUN --mount=type=cache,target=/root/.cache/pip \
 #     --mount=type=bind,source=requirements.txt,target=requirements.txt \
 #     python -m pip install -r requirements.txt
+ARG TRESTLE_VERSION=2.6.1
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python -m pip install compliance-trestle
+    python -m pip install "compliance-trestle==${TRESTLE_VERSION}"
 
 # Switch to the non-privileged user to run the application.
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ COPY OSCAL_REFERENCE.md /app/
 COPY scripts /app/bin
 
 ENV PATH="/app/bin:${PATH}"
+# Allow for skipping automatic install of trestle-config.yaml
+ENV SKIP_TRESTLE_CONFIG=false
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 # Run the application.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -d /app/docs/.trestle ]; then
     trestle init --govdocs
 fi
 
-if [ ! -f /app/docs/trestle-config.yaml ]; then
+if [[ ! -f /app/docs/trestle-config.yaml && "$SKIP_TRESTLE_CONFIG" != "true" ]]; then
     cp /app/templates/trestle-config.yaml .
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,8 @@ if [ ! -d /app/docs/.trestle ]; then
     trestle init --govdocs
 fi
 
+if [ ! -f /app/docs/trestle-config.yaml ]; then
+    cp /app/templates/trestle-config.yaml .
+fi
+
 exec "$@"

--- a/scripts/assemble-ssp-json
+++ b/scripts/assemble-ssp-json
@@ -5,7 +5,7 @@ $0: Assemble markdown controls into an OSCAL JSON SSP
 
 Usage:
     $0 -h
-    $0 [-n SYSTEM_NAME] [-d COMMA_SEP_COMPDEFS] [-m MARKDOWN_DIR] [-r]
+    $0 [-n SYSTEM_NAME] [-c COMMA_SEP_COMPDEFS] [-m MARKDOWN_DIR] [-r]
 
 Options:
 -h: show help and exit

--- a/scripts/assemble-ssp-json
+++ b/scripts/assemble-ssp-json
@@ -5,21 +5,26 @@ $0: Assemble markdown controls into an OSCAL JSON SSP
 
 Usage:
     $0 -h
-    $0 -n SYSTEM_NAME [-c COMMA_SEP_COMPDEFS] [-m MARKDOWN_DIR] [-r]
+    $0 [-n SYSTEM_NAME] [-d COMMA_SEP_COMPDEFS] [-m MARKDOWN_DIR] [-r]
 
 Options:
 -h: show help and exit
--n: System Name
--c: Comma-separated list of ComponentDefinitions to include. Optional
--m: Directory containing markdown files. Defaults to control-statements
+-n: System Name. Defaults to 'system-name' value in trestle-config.yaml
+-c: Comma-separated list of ComponentDefinitions to include. Defaults to 'components:' list in config
+-m: Directory containing markdown files. Defaults to 'markdown' value in config, or 'control-statements'
 -r: Regenerate UUIDs
+
+Notes:
+* Will load defaults from  trestle-config.yaml file, if present
 "
 
 set -e
 
 declare -a optional_args
-markdown="control-statements"
-system_name=""
+source /app/bin/functions.sh
+markdown=$(yaml_parse_value 'trestle-config.yaml' 'markdown' 'control-statements')
+system_name=$(yaml_parse_value 'trestle-config.yaml' 'system-name')
+components=$(yaml_comma_sep_components 'trestle-config.yaml')
 
 while getopts "hn:c:m:r" opt; do
     case "$opt" in
@@ -27,7 +32,7 @@ while getopts "hn:c:m:r" opt; do
             system_name=${OPTARG}
             ;;
         c)
-            optional_args+=("-cd" ${OPTARG})
+            components=${OPTARG}
             ;;
         m)
             markdown=${OPTARG}
@@ -45,6 +50,10 @@ done
 if [ "$system_name" = "" ]; then
     echo "$usage"
     exit 1
+fi
+
+if [ "$components" != "" ]; then
+    optional_args+=("-cd" $components)
 fi
 
 if [ -d "system-security-plans/$system_name" ]; then

--- a/scripts/copy-component
+++ b/scripts/copy-component
@@ -9,7 +9,7 @@ Usage:
 
 Options:
 -h: show help and exit
--n: Local Component Name
+-n: Component Name
 -u: Remote Component URL. Required if COMPONENT_NAME is not shipped in templates folder
 "
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,32 @@
+
+#############################################################################
+# yaml_parse_value(filename, key, default_value=""): helper function to parse
+# a yaml file and retreive the value at a key. default_value is returned
+# if either the file does not exist or the key does not exist
+#############################################################################
+yaml_parse_value() {
+  default_value=${3:-""}
+  if [ -f "$1" ]; then
+    python3 -c "import yaml;config=yaml.safe_load(open('$1'));print(config['$2'] if '$2' in config else '$default_value')"
+  else
+    echo $default_value
+  fi
+}
+#############################################################################
+# yaml_comma_sep_components(filename): helper function to parse a yaml file
+# and output the component names as a comma separated string
+#
+# Expected file format:
+#
+# components:
+#   - first_component
+#   - second_component
+#
+#############################################################################
+yaml_comma_sep_components() {
+  if [ -f "$1" ]; then
+    python3 -c "import yaml;config=yaml.safe_load(open('$1'));cds=config['components'] if 'components' in config else ['']; print(','.join(cds))"
+  else
+    echo ""
+  fi
+}

--- a/scripts/generate-ssp-markdown
+++ b/scripts/generate-ssp-markdown
@@ -5,7 +5,7 @@ $0: Generate control statement markdown for an SSP
 
 Usage:
     $0 -h
-    $0 [-p PROFILE_NAME] [-c COMPONENT_NAMES_SOURCE] [-s LEVERAGED_SSP] [-m MARKDOWN_DIR] [-f]
+    $0 [-p PROFILE_NAME] [-c COMMA_SEP_COMPDEFS] [-s LEVERAGED_SSP] [-m MARKDOWN_DIR] [-f]
 
 Options:
 -h: show help and exit

--- a/scripts/generate-ssp-markdown
+++ b/scripts/generate-ssp-markdown
@@ -5,22 +5,28 @@ $0: Generate control statement markdown for an SSP
 
 Usage:
     $0 -h
-    $0 -p PROFILE_NAME [-c COMMA_SEP_COMPDEFS] [-s LEVERAGED_SSP] [-m MARKDOWN_DIR] [-f]
+    $0 [-p PROFILE_NAME] [-c COMPONENT_NAMES_SOURCE] [-s LEVERAGED_SSP] [-m MARKDOWN_DIR] [-f]
 
 Options:
 -h: show help and exit
--p: Profile name to base the SSP on
--c: Comma-separated list of ComponentDefinitions to include. Optional
--s: SSP to leverage as local name or URL. Optional
--m: Directory to put markdown files in. Defaults to control-statements
+-p: Profile name to base the SSP on. Defaults to 'profile' value in trestle-config.yaml
+-c: Comma-separated list of ComponentDefinitions to include. Defaults to 'components:' list in config
+-s: SSP to leverage as local name or URL. Defaults to 'leveraged-ssp' value in trestle-config.yaml
+-m: Directory to put markdown files in. Defaults to 'markdown' value in config, or 'control-statements'
 -f: Force overwrite
+
+Notes:
+* Will load defaults from trestle-config.yaml file, if present
 "
 
 set -e
 
 declare -a optional_args
-markdown="control-statements"
-profile=""
+source /app/bin/functions.sh
+markdown=$(yaml_parse_value 'trestle-config.yaml' 'markdown' 'control-statements')
+profile=$(yaml_parse_value 'trestle-config.yaml' 'profile')
+leveraged_ssp=$(yaml_parse_value 'trestle-config.yaml' 'leveraged-ssp')
+components=$(yaml_comma_sep_components 'trestle-config.yaml')
 
 while getopts "hp:c:s:m:f" opt; do
     case "$opt" in
@@ -28,10 +34,10 @@ while getopts "hp:c:s:m:f" opt; do
             profile=${OPTARG}
             ;;
         c)
-            optional_args+=("-cd" ${OPTARG})
+            components=${OPTARG}
             ;;
         s)
-            optional_args+=("-ls" ${OPTARG})
+            leveraged_ssp=${OPTARG}
             ;;
         m)
             markdown=${OPTARG}
@@ -53,6 +59,14 @@ fi
 
 if [ ! -d "profiles/$profile" ]; then
     copy-profile "$profile"
+fi
+
+if [ "$components" != "" ]; then
+    optional_args+=("-cd" $components)
+fi
+
+if [ "$leveraged_ssp" != "" ]; then
+    optional_args+=("-ls" $leveraged_ssp)
 fi
 
 trestle author ssp-generate -p "$profile" -o "$markdown" "${optional_args[@]}"

--- a/templates/trestle-config.yaml
+++ b/templates/trestle-config.yaml
@@ -1,0 +1,5 @@
+# trestle-config.yaml file for configuring generate-ssp-markdown and assemble-ssp-json.
+system-name: ""
+profile: ""
+# components:
+#   - component-name


### PR DESCRIPTION
Changes:

* adds a default `trestle-config.yaml` file
* add ability to skip generation of config file, for use cases centered on component-definitions instead of SSPPs
* updates `generate-ssp-markdown` and `assemble-ssp-json` to read defaults from that file
* minor update to `copy-component` argument documentation

closes #12 
closes #11 