### PR TITLE
Update docs for how to create multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
 ARG PYTHON_VERSION=3.11.9
-FROM python:${PYTHON_VERSION}-slim as base
+FROM python:${PYTHON_VERSION}-slim AS base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -55,4 +55,4 @@ ENV SKIP_TRESTLE_CONFIG=false
 ENTRYPOINT ["/app/entrypoint.sh"]
 
 # Run the application.
-CMD trestle version
+CMD ["trestle", "version"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The `/app/docs` directory can be used as a scratch area for any temporary trestl
 ### Updating the Docker image:
 
 1. Make required changes to the Dockerfile
-1. Build the image: `docker build -t ghcr.io/gsa-tts/trestle .`
+1. Build the image: `docker build --platform linux/arm64,linux/amd64 -t ghcr.io/gsa-tts/trestle .`
+
+    > [!TIP]
+    > You may need to [enable containerd image store](https://docs.docker.com/desktop/containerd/#enable-the-containerd-image-store) to support mutli-platform builds.
+
 1. Tag with a datestamp: `docker tag ghcr.io/gsa-tts/trestle ghcr.io/gsa-tts/trestle:YYYYMMDD`
 1. Push the new tag to Docker Hub: `docker push ghcr.io/gsa-tts/trestle:YYYYMMDD`


### PR DESCRIPTION
Changes:

* update instructions to include building images for both apple silicon and amd64/linux/CI environments
* Address a couple of dockerfile warnings