### PR TITLE
Add Auditree rules for cloud.gov-hosted apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ A profile representing the set of controls covered by a [GSA LATO](https://www.g
 
 A Component Definition representing the Cloud.gov CRM.
 
+#### component-definitions/devtools_cloud_gov
+
+A set of testable best practices for running applications on cloud.gov. This component integrates with [Auditree](https://auditree.github.io/) and [c2p](https://github.com/oscal-compass/compliance-to-policy) to generate compliance results
+
 #### catalogs/nist800-53r5
 
 A copy of the full NIST 800-53 revision 5 catalog.

--- a/scripts/assemble-component-json
+++ b/scripts/assemble-component-json
@@ -1,0 +1,50 @@
+#! /usr/bin/env bash
+
+usage="
+$0: Assemble markdown controls into an OSCAL JSON Component Definition
+
+Usage:
+    $0 -h
+    $0 -n COMPONENT_NAME [-m MARKDOWN_DIR] [-r]
+
+Options:
+-h: show help and exit
+-n: Component Name
+-m: Directory containing markdown files. Defaults to COMPONENT_NAME
+-r: Regenerate UUIDs
+"
+
+set -e
+
+declare -a optional_args
+markdown=""
+component_name=""
+
+while getopts "hn:m:r" opt; do
+    case "$opt" in
+        n)
+            component_name=${OPTARG}
+            ;;
+        m)
+            markdown=${OPTARG}
+            ;;
+        r)
+            optional_args+=("-r")
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$component_name" = "" ]; then
+    echo "$usage"
+    exit 1
+fi
+
+if [ "$markdown" = "" ]; then
+    markdown=$component_name
+fi
+
+trestle author component-assemble -o "$component_name" -m "$markdown" "${optional_args[@]}"

--- a/scripts/generate-component-markdown
+++ b/scripts/generate-component-markdown
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+
+usage="
+$0: Generate control statement markdown for a Component Definition
+
+Usage:
+    $0 -h
+    $0 -n COMPONENT_NAME [-m MARKDOWN_DIR]
+
+Options:
+-h: show help and exit
+-n: Component name
+-m: Markdown directory. Defaults to COMPONENT_NAME
+
+Notes:
+* Will always fully overwrite the markdown directory
+"
+
+set -e
+
+markdown=""
+component_name=""
+
+while getopts "hn:m:" opt; do
+    case "$opt" in
+        n)
+            component_name=${OPTARG}
+            ;;
+        m)
+            markdown=${OPTARG}
+            ;;
+        h)
+            echo "$usage"
+            exit 0
+            ;;
+    esac
+done
+
+if [ "$component_name" = "" ]; then
+    echo "$usage"
+    exit 1
+fi
+
+if [ "$markdown" = "" ]; then
+    markdown=$component_name
+fi
+
+trestle author component-generate -n "$component_name" -o "$markdown" -fo

--- a/templates/component-definitions/devtools_cloud_gov/component-definition.json
+++ b/templates/component-definitions/devtools_cloud_gov/component-definition.json
@@ -17,27 +17,52 @@
           {
             "name": "Rule_Id",
             "value": "ssh-access-disabled",
-            "remarks": "rule_ssh_access_disabled"
+            "remarks": "rule_ssh_access_disabled_1"
           },
           {
             "name": "Rule_Description",
             "value": "Production spaces should disable ssh access",
-            "remarks": "rule_ssh_access_disabled"
+            "remarks": "rule_ssh_access_disabled_1"
           },
           {
             "name": "Parameter_Id",
             "value": "gov.cloud.space-names",
-            "remarks": "rule_ssh_access_disabled"
+            "remarks": "rule_ssh_access_disabled_1"
           },
           {
             "name": "Parameter_Description",
             "value": "The cloud.gov spaces in which ssh access should be disabled",
-            "remarks": "rule_ssh_access_disabled"
+            "remarks": "rule_ssh_access_disabled_1"
           },
           {
             "name": "Parameter_Value_Alternatives",
             "value": "TODO - update to comma separated list of production spaces",
-            "remarks": "rule_ssh_access_disabled"
+            "remarks": "rule_ssh_access_disabled_1"
+          },
+          {
+            "name": "Rule_Id",
+            "value": "ssh-access-disabled",
+            "remarks": "rule_ssh_access_disabled_2"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Production spaces should disable ssh access",
+            "remarks": "rule_ssh_access_disabled_2"
+          },
+          {
+            "name": "Parameter_Id",
+            "value": "gov.cloud.org-name",
+            "remarks": "rule_ssh_access_disabled_2"
+          },
+          {
+            "name": "Parameter_Description",
+            "value": "The cloud.gov org in which ssh access should be disabled",
+            "remarks": "rule_ssh_access_disabled_2"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "value": "TODO - update to production org",
+            "remarks": "rule_ssh_access_disabled_2"
           }
         ],
         "control-implementations": [
@@ -46,6 +71,10 @@
             "source": "trestle://catalogs/nist800-53r5/catalog.json",
             "description": "Best practice control content for cloud.gov-hosted applications",
             "set-parameters": [
+              {
+                "param-id": "gov.cloud.org-name",
+                "values": ["TODO - cloud.gov org name"]
+              },
               {
                 "param-id": "gov.cloud.space-names",
                 "values": [
@@ -69,7 +98,7 @@
                   {
                     "statement-id": "sc-7_smt.a",
                     "uuid": "7980db8d-2517-4c1d-a1ac-ab28bceefc35",
-                    "description": "SSH access to production spaces: {{ insert: param, gov.cloud.space-names }} within Cloud.gov has been disabled.",
+                    "description": "SSH access to production spaces: {{ insert: param, gov.cloud.space-names }} within Cloud.gov organization {{ insert: param, gov.cloud.org-name }} has been disabled.",
                     "props": [
                       {
                         "name": "Rule_Id",
@@ -112,7 +141,7 @@
                   {
                     "statement-id": "si-4_smt.b",
                     "uuid": "30e83cb4-8214-491b-85d8-ce85b1a58e9d",
-                    "description": "SSH Access has been disabled to production spaces {{ insert: param, gov.cloud.space-names }} to limit potential unauthorized use.",
+                    "description": "SSH Access has been disabled to production spaces {{ insert: param, gov.cloud.space-names }} in organization {{ insert: param, gov.cloud.org-name }} to limit potential unauthorized use.",
                     "props": [
                       {
                         "name": "Rule_Id",

--- a/templates/component-definitions/devtools_cloud_gov/component-definition.json
+++ b/templates/component-definitions/devtools_cloud_gov/component-definition.json
@@ -36,7 +36,7 @@
           },
           {
             "name": "Parameter_Value_Alternatives",
-            "value": "TODO",
+            "value": "TODO - update to comma separated list of production spaces",
             "remarks": "rule_ssh_access_disabled"
           }
         ],
@@ -49,7 +49,8 @@
               {
                 "param-id": "gov.cloud.space-names",
                 "values": [
-                  "TODO"
+                  "TODO - prod space 1",
+                  "TODO - prod space 2"
                 ]
               }
             ],
@@ -142,13 +143,33 @@
           },
           {
             "name": "Check_Id",
-            "value": "checks.test_cf_ssh.SpaceSSHDisabledCheck",
+            "value": "checks.test_cf_ssh.SpaceSSHDisabledCheck.test_space_ssh_disabled",
             "remarks": "rule_ssh_access_disabled"
           },
           {
             "name": "Check_Description",
             "value": "Validate that ssh access has been disabled to gov.cloud.space-names spaces",
             "remarks": "rule_ssh_access_disabled"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "26a1c0f5-e6af-49ef-9116-3044d5a26f57",
+            "source": "trestle://catalogs/nist800-53r5/catalog.json",
+            "description": "",
+            "implemented-requirements": [
+              {
+                "uuid": "0f916da6-3c71-4389-8048-5d57a0dfd1a4",
+                "control-id": "na",
+                "description": "List of Rules that Auditree is checking",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "value": "ssh-access-disabled"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/templates/component-definitions/devtools_cloud_gov/component-definition.json
+++ b/templates/component-definitions/devtools_cloud_gov/component-definition.json
@@ -1,0 +1,157 @@
+{
+  "component-definition": {
+    "uuid": "d8c6b192-f2c1-4434-8307-d8aed1826fe6",
+    "metadata": {
+      "title": "Cloud.gov Best Practices for DevTools-based applications.",
+      "last-modified": "2024-08-15T01:28:29.538446+00:00",
+      "version": "0.0.1",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "f1815d23-9f15-4824-b7c3-b5e4df26f7cc",
+        "type": "policy",
+        "title": "DevTools Cloud.gov",
+        "description": "A set of testable best practices for cloud.gov hosted apps.",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "value": "ssh-access-disabled",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Rule_Description",
+            "value": "Production spaces should disable ssh access",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Parameter_Id",
+            "value": "gov.cloud.space-names",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Parameter_Description",
+            "value": "The cloud.gov spaces in which ssh access should be disabled",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "value": "TODO",
+            "remarks": "rule_ssh_access_disabled"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "cae08b2c-4d1f-4900-9d04-ebdc76cac54e",
+            "source": "trestle://catalogs/nist800-53r5/catalog.json",
+            "description": "Best practice control content for cloud.gov-hosted applications",
+            "set-parameters": [
+              {
+                "param-id": "gov.cloud.space-names",
+                "values": [
+                  "TODO"
+                ]
+              }
+            ],
+            "implemented-requirements": [
+              {
+                "uuid": "1b961b4e-96ea-4ef1-a48b-d21386949450",
+                "control-id": "sc-7",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "sc-7_smt.a",
+                    "uuid": "7980db8d-2517-4c1d-a1ac-ab28bceefc35",
+                    "description": "SSH access to production spaces: {{ insert: param, gov.cloud.space-names }} within Cloud.gov has been disabled.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "ssh-access-disabled"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "implemented"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "uuid": "ef2726a2-b454-4deb-8a49-2aa9290639cd",
+                "control-id": "si-4",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "value": "planned"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "si-4_smt.a",
+                    "uuid": "756bae92-4f20-47d9-80c1-41345a725b1d",
+                    "description": "The only type of remote connections available within cloud.gov are via SSH to the application containers. There is no other ability for local, remote, or network connections. By default, SSH access to the production space is turned off, except in the event of a security investigation or application failure/performance issues by System Administrators.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "ssh-access-disabled"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "implemented"
+                      }
+                    ]
+                  },
+                  {
+                    "statement-id": "si-4_smt.b",
+                    "uuid": "30e83cb4-8214-491b-85d8-ce85b1a58e9d",
+                    "description": "SSH Access has been disabled to production spaces {{ insert: param, gov.cloud.space-names }} to limit potential unauthorized use.",
+                    "props": [
+                      {
+                        "name": "Rule_Id",
+                        "value": "ssh-access-disabled"
+                      },
+                      {
+                        "name": "implementation-status",
+                        "value": "implemented"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "d90f3053-a333-4b3c-9ff1-d726e29eaffa",
+        "type": "validation",
+        "title": "Auditree",
+        "description": "Auditree checks for Devtools best practices",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "value": "ssh-access-disabled",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Check_Id",
+            "value": "checks.test_cf_ssh.SpaceSSHDisabledCheck",
+            "remarks": "rule_ssh_access_disabled"
+          },
+          {
+            "name": "Check_Description",
+            "value": "Validate that ssh access has been disabled to gov.cloud.space-names spaces",
+            "remarks": "rule_ssh_access_disabled"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First cut at adding a simple component encapsulating testable best practices for cloud.gov-hosted apps.

Still to do:

- [x] decide if auditree rules should be bundled in this docker image, or delivered separately.
- [x] decide if the docker image is the best delivery for the component, or if it should be hosted within devtools-compliance

Work towards https://github.com/GSA-TTS/devtools-program/issues/90