### PR TITLE
Upgrade to trestle 3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN adduser \
 # RUN --mount=type=cache,target=/root/.cache/pip \
 #     --mount=type=bind,source=requirements.txt,target=requirements.txt \
 #     python -m pip install -r requirements.txt
-ARG TRESTLE_VERSION=3.3.0
+ARG TRESTLE_VERSION=3.4.0
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install "compliance-trestle==${TRESTLE_VERSION}"
 

--- a/scripts/generate-ssp-markdown
+++ b/scripts/generate-ssp-markdown
@@ -69,4 +69,4 @@ if [ "$leveraged_ssp" != "" ]; then
     optional_args+=("-ls" $leveraged_ssp)
 fi
 
-trestle author ssp-generate -p "$profile" -o "$markdown" "${optional_args[@]}"
+trestle author ssp-generate -p "$profile" -o "$markdown" -iap "${optional_args[@]}"


### PR DESCRIPTION
Changes:

* install trestle 3.4 [CHANGELOG](https://github.com/oscal-compass/compliance-trestle/blob/develop/CHANGELOG.md#v340-2024-08-23)
* Include the `-iap` parameter when generating SSP markdown to output `This System` component into all parts of the control

Closes #21 