### PR TITLE
Update frontmatter to pull revision details

### DIFF
--- a/OSCAL_REFERENCE.md
+++ b/OSCAL_REFERENCE.md
@@ -21,7 +21,7 @@ For docker-trestle, the `control-implementation` section is maintained and edite
 | `version` | Version of the SSP document. Revise whenever submitting final doc for approvals |
 | `oscal-version` | Version of OSCAL in use. trestle currently supports `1.1.2` |
 | `revisions` | Version history of the document. Used to populate `Document Revision History` table in the templates |
-| `roles` | Names of roles referenced within `responsible-parties` lists. |
+| `roles` | Names of roles referenced within `responsible-parties` lists |
 | `parties` | People and organizations involved with the creation of the System and SSPP |
 | `responsible-parties` | Mappings of parties to roles |
 

--- a/OSCAL_REFERENCE.md
+++ b/OSCAL_REFERENCE.md
@@ -19,7 +19,11 @@ For docker-trestle, the `control-implementation` section is maintained and edite
 | `title` | Title of the SSPP document |
 | `last-modified` | Do not edit - automatically generated timestamp |
 | `version` | Version of the SSP document. Revise whenever submitting final doc for approvals |
-| `oscal-version` | Version of OSCAL in use. trestle currently supports `1.0.4` |
+| `oscal-version` | Version of OSCAL in use. trestle currently supports `1.1.2` |
+| `revisions` | Version history of the document. Used to populate `Document Revision History` table in the templates |
+| `roles` | Names of roles referenced within `responsible-parties` lists. |
+| `parties` | People and organizations involved with the creation of the System and SSPP |
+| `responsible-parties` | Mappings of parties to roles |
 
 ### System Characteristics
 

--- a/templates/ssp-rendering/lato/templates/frontmatter.md
+++ b/templates/ssp-rendering/lato/templates/frontmatter.md
@@ -39,8 +39,12 @@ Document Prepared By
 
 Document Revision History
 
+{% set prepared_by = ssp_interface.first_array_entry(ssp_interface.get_parties_for_role(ssp.metadata.responsible_parties, "prepared-by")) %}
 | Date | Comments | Version | Author |
 | ---- | -------- | ------- | ------ |
-| | | | |
+{% for revision in ssp_interface.safe_retrieval(ssp.metadata, 'revisions', []) %}
+{% set revision_prepared_by = ssp_interface.get_party_by_uuid(control_interface.get_prop(revision, 'prepared-by')) or prepared_by %}
+| {{ revision.last_modified.strftime('%Y-%m-%d') if revision.last_modified else '' }} | {{ revision.title }} | {{ revision.version }} | {{ revision_prepared_by.name }} |
+{% endfor %}
 
 <div class="pagebreak"></div>


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: https://github.com/GSA-TTS/devtools-compliance/issues/25
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* pull document revision history table details from `metadata.revisions`
* Uses an optional non-standard prop to the revisions object with name `prepared-by` and value of a party uuid to populate the "author" of each revision. Otherwise it falls back to the first 'prepared-by' responsible party.
* updates the OSCAL_REFERENCE table with more metadata details

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
