### PR TITLE
Add flag to display control status summarized by family

### DIFF
--- a/scripts/control-status
+++ b/scripts/control-status
@@ -5,13 +5,14 @@ $0: Get rough list of implementation statuses from control markdown files
 
 Usage:
   $0 -h
-  $0 [-s INCLUDE_STATUS_LIST] [-i IGNORED_STATUS_LIST] [-m MARKDOWN_DIR]
+  $0 [-s INCLUDE_STATUS_LIST] [-i IGNORED_STATUS_LIST] [-m MARKDOWN_DIR] [-f]
 
 Options:
 -h: show help and exit
 -s: status names to include, given as comma separated list. Defaults to all controls
 -i: status names to ignore, given as comma separated list.
 -m: Directory containing markdown files. Defaults to 'markdown' value in config, or 'control-statements'
+-f: Summarize counts by control family
 
 Notes:
 * passing '-s' will take precedence over '-i'
@@ -23,9 +24,13 @@ source /app/bin/functions.sh
 markdown=$(yaml_parse_value 'trestle-config.yaml' 'markdown' 'control-statements')
 ignored=""
 status=""
+summarize_by_family="false"
 
-while getopts "hs:i:m:" opt; do
+while getopts "hfs:i:m:" opt; do
   case "$opt" in
+    f)
+      summarize_by_family="true"
+      ;;
     s)
       status=`sed s/,/"\\\\\|"/g <<< ${OPTARG}`
       ;;
@@ -52,8 +57,11 @@ if [ "$status" != "" ]; then
 elif [ "$ignored" != "" ]; then
   result=`grep -v $ignored <<< $result`
 fi
-
 cat <<< $result
+
+if [ "$summarize_by_family" = "true" ]; then
+  result=`awk -F'[-:]' '{print $1 $3}' <<< $result`
+fi
 echo "==========================================================================="
 echo "$(wc -l <<< $result) controls found"
 cut -d':' -f2 <<< $result | sort | uniq -c


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: no issue
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* add a flag to display control status summarized by the control family

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>default behavior</summary>
<img width="351" alt="Screenshot 2024-11-15 at 8 42 24 AM" src="https://github.com/user-attachments/assets/571bef8f-99d6-496c-bc3e-6b48e222b8e3">

</details>

<details>
<summary>output with flag given</summary>
<img width="350" alt="Screenshot 2024-11-15 at 8 42 51 AM" src="https://github.com/user-attachments/assets/183e5bfa-7015-4ea2-9c87-2bf42ca12469">

</details>
