### PR TITLE
Always print filename header for grep, even if only one file exists

### DIFF
--- a/scripts/control-status
+++ b/scripts/control-status
@@ -51,7 +51,7 @@ echo "==========================================================================
 echo "Gap report for /app/docs/$markdown"
 echo "==========================================================================="
 
-result=`grep -R "Implementation Status:" /app/docs/"$markdown"/* | cut -d':' -f1,3 | awk -F'/' '{print $NF}'`
+result=`grep -H -R "Implementation Status:" /app/docs/"$markdown"/* | cut -d':' -f1,3 | awk -F'/' '{print $NF}'`
 if [ "$status" != "" ]; then
   result=`grep $status <<< $result`
 elif [ "$ignored" != "" ]; then


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #57 
<!--
Insert the issue number (or full link if the issue is in a different repo
-->
closes #57 

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* use the `-H` flag for grep to ensure it always prints the name of the file that the match came from.

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
