### PR TITLE
fix: override au-2_prm_2 label to remove broken cross-reference

### DIFF
--- a/templates/profiles/lato/profile.json
+++ b/templates/profiles/lato/profile.json
@@ -262,7 +262,8 @@
           ]
         },
         {
-          "param-id": "au-2_prm_2"
+          "param-id": "au-2_prm_2",
+          "label": "organization-defined event types (subset of the event types defined in AU-2a.) along with the frequency of (or situation requiring) logging for each identified event type"
         },
         {
           "param-id": "au-06.01_odp",


### PR DESCRIPTION
## Problem

The NIST SP 800-53 Rev 5 catalog defines the label for aggregate parameter `au-2_prm_2` with a markdown cross-reference:

```
[AU-2a.](#au-2_smt.a)
```

This link targets a per-statement anchor (`#au-2_smt.a`) that trestle's SSP renderer (`trestle author jinja`) does not emit. When the rendered SSP markdown is converted to PDF via pandoc/xelatex, this produces:

```
[WARNING] [makePDF] LaTeX Warning: Hyper reference `au-2_smt.a' on page 104 undefined
```

The link is also dead in HTML and DOCX output formats.

## Fix

Override the `au-2_prm_2` label in the LATO profile to use plain text `AU-2a.` instead of the markdown link `[AU-2a.](#au-2_smt.a)`. The readable content is identical — only the broken anchor is removed.

## Verification

- Checked all 9 other empty aggregate parameter stubs in the LATO profile — none have similar cross-reference issues
- This is the only parameter in the NIST catalog (among LATO-included controls) whose label contains a `](#..._smt...)` cross-reference